### PR TITLE
ENH: Extend python wrapping to any image type

### DIFF
--- a/wrapping/itkBinaryThinningImageFilter3D.wrap
+++ b/wrapping/itkBinaryThinningImageFilter3D.wrap
@@ -1,4 +1,6 @@
 itk_wrap_class("itk::BinaryThinningImageFilter3D" POINTER)
   UNIQUE(wrap_image_types "${WRAP_ITK_SCALAR};UC")
-  itk_wrap_image_filter("${wrap_image_types}" 3)
+  foreach(type ${wrap_image_types})
+    itk_wrap_image_filter_combinations("${type}" "${type}" 3)
+  endforeach()
 itk_end_wrap_class()

--- a/wrapping/itkBinaryThinningImageFilter3D.wrap
+++ b/wrapping/itkBinaryThinningImageFilter3D.wrap
@@ -1,4 +1,6 @@
 itk_wrap_class("itk::BinaryThinningImageFilter3D" POINTER)
-  itk_wrap_template("${ITKM_I${ITKM_UC}3}${ITKM_I${ITKM_UC}3}"
-                    "${ITKT_I${ITKM_UC}3}, ${ITKT_I${ITKM_UC}3}")
+  UNIQUE(wrap_image_types "${WRAP_ITK_SCALAR};UC")
+  foreach(type ${wrap_image_types})
+    itk_wrap_image_filter_combinations("${type}" "UC" 3)
+  endforeach()
 itk_end_wrap_class()

--- a/wrapping/itkBinaryThinningImageFilter3D.wrap
+++ b/wrapping/itkBinaryThinningImageFilter3D.wrap
@@ -1,6 +1,4 @@
 itk_wrap_class("itk::BinaryThinningImageFilter3D" POINTER)
   UNIQUE(wrap_image_types "${WRAP_ITK_SCALAR};UC")
-  foreach(type ${wrap_image_types})
-    itk_wrap_image_filter_combinations("${type}" "UC" 3)
-  endforeach()
+  itk_wrap_image_filter("${wrap_image_types}" 3)
 itk_end_wrap_class()


### PR DESCRIPTION
extend <itkTemplate itk::BinaryThinningIamgeFilter3D> options from:
`[<class 'itkImagePython.itkImageUC3'>, <class 'itkImagePython.itkImageUC3'>]`
to virtually any scalar type: `['UC', 'UL', 'US', 'SC', 'SL', 'SS', 'F', 'D']`